### PR TITLE
Add metadata for commands-wiki-cli

### DIFF
--- a/src/content/docs/commands/files.md
+++ b/src/content/docs/commands/files.md
@@ -10,6 +10,8 @@ This is a command for compressing a directory or a file into a `.tar.gz` file
 ```bash
 tar -czvf <file_name>.tar.gz <files/directories>
 ```
+[file_name]: <> (placeholder=archive validation="regex [A-Za-z\d\s]+" desc="This is the name of the archive to write without the .tar.gz part")
+[files/directories]: <> (placeholder=* validation="regex .+" desc="This is a list of all files to include in the archive, the files are separated with spaces")
 
 1. `tar`: This is the command-line utility for handling tape archives (tar). It is commonly used for bundling files and directories together.
 

--- a/src/content/docs/commands/files.md
+++ b/src/content/docs/commands/files.md
@@ -10,7 +10,7 @@ This is a command for compressing a directory or a file into a `.tar.gz` file
 ```bash
 tar -czvf <file_name>.tar.gz <files/directories>
 ```
-[file_name]: <> (placeholder=archive validation="regex [A-Za-z\d\s]+" desc="This is the name of the archive to write without the .tar.gz part")
+[file_name]: <> (placeholder=archive validation="regex [A-Za-z\d\s-_\.]+" desc="This is the name of the archive to write without the .tar.gz part")
 [files/directories]: <> (placeholder=* validation="regex .+" desc="This is a list of all files to include in the archive, the files are separated with spaces")
 
 1. `tar`: This is the command-line utility for handling tape archives (tar). It is commonly used for bundling files and directories together.

--- a/src/content/docs/commands/files.md
+++ b/src/content/docs/commands/files.md
@@ -10,7 +10,7 @@ This is a command for compressing a directory or a file into a `.tar.gz` file
 ```bash
 tar -czvf <file_name>.tar.gz <files/directories>
 ```
-[file_name]: <> (placeholder=archive validation="regex [A-Za-z\d\s-_\.]+" desc="This is the name of the archive to write without the .tar.gz part")
+[file_name]: <> (placeholder=archive validation="regex [A-Za-z\d\s\-_\.]+" desc="This is the name of the archive to write without the .tar.gz part")
 [files/directories]: <> (placeholder=* validation="regex .+" desc="This is a list of all files to include in the archive, the files are separated with spaces")
 
 1. `tar`: This is the command-line utility for handling tape archives (tar). It is commonly used for bundling files and directories together.

--- a/src/content/docs/commands/media.md
+++ b/src/content/docs/commands/media.md
@@ -33,6 +33,8 @@ Converts images and compresses them
 ```bash
 convert <from> -quality 70 <to>
 ```
+[from]: <> (placeholder=img.png validation="file image/.+" desc="The filename of the source file")
+[to]: <> (placeholder=output.png validation="regex (.+)\.(.+)" desc="The filename of the destination file with its file extension")
 This uses the `convert` utility from [ImageMagick](https://www.imagemagick.org/) to convert an image file `<from>` another file named `<to>`, while also compressing the image quality to `70%`.
 
 ### Crop transparent background from image
@@ -40,6 +42,8 @@ This command is using the `convert` command from the [ImageMagick](https://www.i
 ```bash
 convert <from> -trim +repage <to>
 ```
+[from]: <> (placeholder=img.png validation="file image/.+" desc="The filename of the source file")
+[to]: <> (placeholder=output.png validation="regex (.+)\.(.+)" desc="The filename of the destination file with its file extension")
 1. `convert <from>`: This initiates the conversion process using the ImageMagick `convert` command, and it specifies the input file as `<from>`.
 
 2. `-trim`: This option instructs ImageMagick to trim away any surrounding transparent or near-transparent pixels from the edges of the image, effectively removing the transparent background.
@@ -55,6 +59,8 @@ This command crops an image and removes its near transparent pixels in order to 
 ```bash
 convert <from> -trim +repage -resize 180x180 <to>.ico
 ```
+[from]: <> (placeholder=favicon.png validation="file image/.+" desc="The filename of the source file")
+[to]: <> (placeholder=favicon validation="regex (.+)\.(?:(?!ico))(.+)" desc="The filename of the .ico file without the .ico part")
 1. `convert <from>`: This initiates the conversion process using the ImageMagick `convert` command and specifies the input file as `<from>`, replace `<from>` with the name of the file you are trying to crop and convert.
 
 2. `-trim`: This option instructs ImageMagick to trim away any surrounding transparent or near-transparent pixels from the edges of the image, effectively removing the transparent background.

--- a/src/content/docs/commands/media.md
+++ b/src/content/docs/commands/media.md
@@ -60,7 +60,7 @@ This command crops an image and removes its near transparent pixels in order to 
 convert <from> -trim +repage -resize 180x180 <to>.ico
 ```
 [from]: <> (placeholder=favicon.png validation="file image/.+" desc="The filename of the source file")
-[to]: <> (placeholder=favicon validation="regex (.+)\.(?:(?!ico))(.+)" desc="The filename of the .ico file without the .ico part")
+[to]: <> (placeholder=favicon validation="regex (.+)" desc="The filename of the .ico file without the .ico part")
 1. `convert <from>`: This initiates the conversion process using the ImageMagick `convert` command and specifies the input file as `<from>`, replace `<from>` with the name of the file you are trying to crop and convert.
 
 2. `-trim`: This option instructs ImageMagick to trim away any surrounding transparent or near-transparent pixels from the edges of the image, effectively removing the transparent background.

--- a/src/content/docs/commands/misc.md
+++ b/src/content/docs/commands/misc.md
@@ -11,6 +11,7 @@ This is a command for decrypting all files for a user when using SSE in Nextclou
 ```bash
 sudo -u www-data php occ encryption:decrypt-all <USERNAME>
 ```
+[USERNAME]: <> (placeholder=username validation="regex .+" desc="The username of the Nextcloud user to decrypt all files for")
 Here's a breakdown:
 
 - `sudo -u www-data`: This runs the following command as the `www-data` user, which is typically the user that runs the web server and has the necessary permissions to access Nextcloud's files.
@@ -30,6 +31,7 @@ mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '<new_password>'; 
 sudo killall -QUIT mysql mysqld_safe mysqld
 sudo systemctl start mysql
 ```
+[new_password]: <> (type=password validation="regex .{8,}" desc="The new password for the user 'root'@'localhost'")
 1. `sudo systemctl stop mysql`: This command stops the MySQL service. It's necessary to stop the service before we can start it in safe mode.
 
 2. `sudo mysqld_safe --skip-grant-tables --skip-networking &`: This command starts the MySQL service in safe mode. The `--skip-grant-tables` option allows us to connect to the database without a password and with all privileges, and `--skip-networking` prevents other clients from connecting to the database.
@@ -47,6 +49,7 @@ sudo timedatectl list-timezones
 sudo timedatectl set-timezone <timezone>
 sudo timedatectl
 ```
+[timezone]: <> (placeholder="Europe/Stockholm" desc="The timezone to set your computer to")
 1. `sudo timedatectl list-timezones`: This command lists all available timezones.
 
 2. `sudo timedatectl set-timezone <timezone>`: This command sets the system timezone to some timezone. One example of a timezone is `Europe/Stockholm`.
@@ -80,7 +83,7 @@ Lists all unique values for fields in all json files in the current directory.
 ```bash
 find . -type f -name "*.json" | xargs cat {} | jq .<name_of_the_field> -c | sort | uniq
 ```
-
+[name_of_the_field]: <> (placeholder=status desc="The path to a field in the json file")
 The command is a pipeline of several commands:
 1. `find . -type f -name "*.json"`: This command searches for all JSON files in the current directory and its subdirectories. The `.` specifies the current directory as the starting point for the search. `-type f` restricts the search to files, and `-name "*.json"` matches any file that ends with `.json`.
 2. `xargs cat {}`: This command reads items from the standard input (in this case, the list of JSON files found by the `find` command), and executes the `cat` command for each item. The `cat` command concatenates and prints the contents of the files.

--- a/src/content/docs/commands/networking.md
+++ b/src/content/docs/commands/networking.md
@@ -12,7 +12,8 @@ This command creates a dummy network interface and assigns it an IP address.
 ip link add <interface_name> type dummy &&
 sudo ip addr add <cidr> brd + dev <interface_name> label <interface_name>:0
 ```
-
+[interface_name]: <> (placeholder=vip0 validation="regex [a-z\d]+" desc="The name of the interface to create")
+[cidr]: <> (placeholder="10.0.0.1/16" validation="regex ([0-9]{1,3}\.){3}[0-9]{1,3}(\/(([0-9]|[12][0-9]|3[0-2])))")
 1. `ip link add <interface_name> type dummy`: Creates a new dummy network interface named `<interface_name>`. Replace `<interface_name>` with the name you want for the interface, one example being `vip0`.
 2. `sudo ip addr add <cidr> brd + dev <interface_name> label <interface_name>:0`: Assigns the cidr `<cidr>` to the interface `<interface_name>`, the cidr should be in the format of `<ip>/<subnetmask>`. Please replace the `<cidr>` with the one that fits your network. The `brd +` option sets the broadcast address to the default value. The `label <interface_name>:0` option assigns a label to the interface.
 
@@ -22,6 +23,7 @@ Prints out all applications running on a certain port
 ```bash
 sudo lsof -i :<PORT>
 ```
+[PORT]: <> (placeholder=80 validation="regex (6553[0-5]|655[0-2]\d|65[0-4]\d{2}|6[0-4]\d{3}|[1-5]\d{4}|[1-9]\d{0,3" desc="Portnumber that should be checked")
 - `sudo`: This runs the following command with root privileges, which are often required to inspect network activity.
 
 - `lsof -i :<PORT>`: lsof is a command meaning 'list open files', and the `-i` option tells it to list files using Internet addresses. `:<PORT>` should be replaced with the port number you're interested in. For example, `:80` would list all processes using port `80`.
@@ -31,6 +33,7 @@ Connects to a smtp server using openssl
 ```bash
 openssl s_client -connect <ip/hostname>:587 -starttls smtp
 ```
+[ip/hostname]: <> (placeholder=mail.gmail.com validation="regex (([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])|(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])" desc="The ip/hostname of the server to connect to using smtp")
 - `openssl s_client`: This starts the OpenSSL client.
 
 - `-connect <ip/hostname>:587`: This tells the client to connect to the SMTP server at the specified IP address or hostname on port 587. Replace <ip/hostname> with the actual IP address or hostname of the server.
@@ -40,7 +43,8 @@ openssl s_client -connect <ip/hostname>:587 -starttls smtp
 ### Generate a standalone certificate
 Generates a standalone certificate using certbot.
 ```bash
-sudo certbot certbot --standalone -d <dns-name>
+sudo certbot certonly --standalone -d <dns-name>
 ```
-- `certbot certbot --standalone`: Runs Certbot in standalone mode, which means it will temporarily start a web server for the certificate validation process.
+[dns-name]: <> (placeholder=example.org validation="regex (([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])" desc="The domain/subdomain to generate a certificate for")
+- `certbot certonly --standalone`: Runs Certbot in standalone mode, which means it will temporarily start a web server for the certificate validation process.
 - `-d <dns-name>`: Specifies the domain name for which the certificate should be issued. Replace `<dns-name>` with your domain name.

--- a/src/content/docs/commands/networking.md
+++ b/src/content/docs/commands/networking.md
@@ -23,7 +23,7 @@ Prints out all applications running on a certain port
 ```bash
 sudo lsof -i :<PORT>
 ```
-[PORT]: <> (placeholder=80 validation="regex (6553[0-5]|655[0-2]\d|65[0-4]\d{2}|6[0-4]\d{3}|[1-5]\d{4}|[1-9]\d{0,3" desc="Portnumber that should be checked")
+[PORT]: <> (placeholder=80 validation="regex (6553[0-5]|655[0-2]\d|65[0-4]\d{2}|6[0-4]\d{3}|[1-5]\d{4}|[1-9]\d{0,3})" desc="Portnumber that should be checked")
 - `sudo`: This runs the following command with root privileges, which are often required to inspect network activity.
 
 - `lsof -i :<PORT>`: lsof is a command meaning 'list open files', and the `-i` option tells it to list files using Internet addresses. `:<PORT>` should be replaced with the port number you're interested in. For example, `:80` would list all processes using port `80`.


### PR DESCRIPTION
This pr adds metadata to be used by [cwc](https://github.com/BL19/commands-wiki-cli) (commands-wiki-cli) for various purposes.

All commands that have variables should have metadata attached to them.

Validations have been implemented using regex and file mimetype checking.

Passwords are entered in a password field.